### PR TITLE
Add options to server cache key invocation

### DIFF
--- a/src/create-request-handler.ts
+++ b/src/create-request-handler.ts
@@ -22,7 +22,7 @@ function createRequestListener({
   return async (req, res) => {
     try {
       const serializedRequest: SerializedRequest = req.body;
-      const cacheKey = await calculateCacheKey(serializedRequest.url);
+      const cacheKey = await calculateCacheKey(serializedRequest.url, serializedRequest);
 
       const requestState = cache.get(cacheKey) || { state: 'initial' };
 


### PR DESCRIPTION
This enables using the options object to calculate the cache key on the proxy server-side.

Especially useful when needing to have caching for `POST` requests, often used for graphql APIs.